### PR TITLE
Raise FileNotFoundError in query_scene_fname()

### DIFF
--- a/pythonbits/scene.py
+++ b/pythonbits/scene.py
@@ -68,6 +68,8 @@ def query_scene_fname(path):
         query = os.path.splitext(os.path.basename(path))[0]
     elif os.path.isdir(path):
         query = os.path.basename(path)
+    elif not os.path.exists(path):
+        raise FileNotFoundError('File or directory not found: %s' % (path,))
     else:
         raise Exception('wat')
 


### PR DESCRIPTION
In case of a wrong path, this increases the length as well as the informational
value of the error message by at least nineteen.

'wat' is still raised in rarer circumstances to share the programm's confusion
with the user.