### PR TITLE
Limit tag length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ wheels/
 *.egg
 MANIFEST
 .tox
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ wheels/
 MANIFEST
 .tox
 .python-version
+venv

--- a/pythonbits/bb.py
+++ b/pythonbits/bb.py
@@ -263,7 +263,13 @@ class VideoSubmission(BbSubmission):
         tags += [a['name']
                  for a in self['summary']['cast'][:n]
                  if a['name']]
-        return ",".join(format_tag(tag) for tag in tags)
+
+        # Maximum tags length is 200 characters
+        def tags_string(tags):
+            return ",".join(format_tag(tag) for tag in tags)
+        while len(tags_string(tags)) > 200:
+            del tags[-1]
+        return tags_string(tags)
 
     def _render_mediainfo_path(self):
         assert os.path.exists(self['path'])

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "progressbar2~=3.38",
     ],
     python_requires=">=3.5,<4.0",
-    tests_require=['tox', 'pytest', 'flake8'],
+    tests_require=['tox', 'pytest', 'flake8', 'pytest-logbook'],
     classifiers=[
         "Operating System :: OS Independent",
         "Programming Language :: Python",


### PR DESCRIPTION
Uploading tags with more than 200 characters raises a general exception.

This removes single tags until the entire string is less than 200 characters long.