### PR TITLE
Fix audio_codec detection for lower-case "codec_id"

### DIFF
--- a/pythonbits/bb.py
+++ b/pythonbits/bb.py
@@ -498,8 +498,8 @@ class VideoSubmission(BbSubmission):
             audio_track['codec_id'] = audio_track['codec_id'][2:]
         # Could be "ac-3"
         audio_track['codec_id'] = audio_track['codec_id'].upper()
-        audio_codecs = ('AC3', 'AC-3', 'EAC3', 'DTS', 'FLAC', 'AAC', 'MP3', 'TRUEHD',
-                        'PCM', '2000')
+        audio_codecs = ('AC3', 'AC-3', 'EAC3', 'DTS', 'FLAC', 'AAC', 'MP3',
+                        'TRUEHD', 'PCM', '2000')
         for c in audio_codecs:
             if audio_track['codec_id'].startswith(c):
                 c = c.replace('EAC3', 'AC-3') \

--- a/pythonbits/bb.py
+++ b/pythonbits/bb.py
@@ -496,7 +496,9 @@ class VideoSubmission(BbSubmission):
 
         if audio_track['codec_id'].startswith('A_'):
             audio_track['codec_id'] = audio_track['codec_id'][2:]
-        audio_codecs = ('AC3', 'EAC3', 'DTS', 'FLAC', 'AAC', 'MP3', 'TRUEHD',
+        # Could be "ac-3"
+        audio_track['codec_id'] = audio_track['codec_id'].upper()
+        audio_codecs = ('AC3', 'AC-3', 'EAC3', 'DTS', 'FLAC', 'AAC', 'MP3', 'TRUEHD',
                         'PCM', '2000')
         for c in audio_codecs:
             if audio_track['codec_id'].startswith(c):


### PR DESCRIPTION
I just saw `"ac-3"` as the value of `audio_track["codec_id"]`.